### PR TITLE
Fix utils.pyqt6 import error

### DIFF
--- a/kuma/jpdb_api.py
+++ b/kuma/jpdb_api.py
@@ -11,7 +11,7 @@ import aqt.editor
 
 from .anki import KumaAnki, is_in_deck
 from .jpdb import JPDB_Note, get_pitch_html, PITCH_DICTIONARY
-from utils.pyqt6 import LineEditRadioButton
+from .utils.pyqt6 import LineEditRadioButton
 
 
 @dataclass


### PR DESCRIPTION
The addon failed on Anki startup with this:
```python
Anki 24.11 (87ccd24e)  (ao)
Python 3.9.18 Qt 6.6.2 PyQt 6.6.1
Platform: Windows-10-10.0.26100

When loading kuma:
Traceback (most recent call last):
  File "aqt.addons", line 250, in loadAddons
  File "C:\Users\Lambda\AppData\Roaming\Anki2\addons21\kuma\__init__.py", line 10, in <module>
    from .addon import open_interface
  File "C:\Users\Lambda\AppData\Roaming\Anki2\addons21\kuma\addon.py", line 10, in <module>
    from .widget import Anki_SearchWidget
  File "C:\Users\Lambda\AppData\Roaming\Anki2\addons21\kuma\widget.py", line 21, in <module>
    from .jpdb_api import JpdbAPI, to_jpdb_note, Note
  File "C:\Users\Lambda\AppData\Roaming\Anki2\addons21\kuma\jpdb_api.py", line 14, in <module>
    from utils.pyqt6 import LineEditRadioButton
ModuleNotFoundError: No module named 'utils.pyqt6'; 'utils' is not a package
```
